### PR TITLE
Add TLS/SSL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Socket.IO Lib uses _asio_, _rapidjson_, and _websocketpp_. SIOJson is originally
 [Unreal Forum Thread](https://forums.unrealengine.com/showthread.php?110680-Plugin-Socket-io-Client)
 
 
-Recommended socket.io server version: 1.4+.
+Recommended socket.io server version: 3.0+
 
 *Tip: This is a sizeable readme, quickly find your topic with ```Ctrl+F``` and a search term e.g. namespaces*
 
@@ -22,8 +22,34 @@ Current platform issues:
 * Xbox/PS4 platform untested - see [issue 117](https://github.com/getnamo/SocketIOClient-Unreal/issues/117)
 * Lumin platform untested - see [issue 114](https://github.com/getnamo/SocketIOClient-Unreal/issues/114)
 
-HTTPS currently not yet supported
-* OpenSSL Support - Available under separate branch https://github.com/getnamo/SocketIOClient-Unreal/tree/ssl. Issue tracked here: [issue39](https://github.com/getnamo/SocketIOClient-Unreal/issues/39)
+Current TLS/SSL issues:
+
+* Certification verification is not implemented; setting `bShouldSkipCertificateVerification` will always fail - see [issue 303](https://github.com/getnamo/SocketIOClient-Unreal/issues/303)
+
+## Socket.IO Server Compatibility
+
+Some features in later versions of this plugin are not supported by earlier versions of the Socket.IO server API. See the compatibility table below for more details
+
+<table>
+  <tr>
+    <th rowspan="2">UE4 Socket.IO plugin version</th>
+    <th colspan="2">Socket.IO server version</th>
+  </tr>
+  <tr>
+    <td align="center">1.x / 2.x</td>
+    <td align="center">3.x / 4.x</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/getnamo/socketio-client-ue4/releases/tag/v2.0.1">v2.0.1 and earlier</a></td>
+    <td align="center">YES</td>
+    <td align="center">NO</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/dobby5/socketio-client-ue4">v2.1.0 and later</a></td>
+    <td align="center">NO</td>
+    <td align="center">YES</td>
+  </tr>
+</table>
 
 ## Quick Install & Setup ##
 
@@ -772,6 +798,12 @@ You can post simple JSON requests using the SIOJRequest (this is the same archit
 ![Sending a JSON post request](https://i.imgur.com/UOJHcP0.png)
 
 These request functions are available globally.
+
+## TLS / SSL
+
+TLS is supported for both C++ and BP without recompiling the plugin to switch between no TLS and TLS. To use it, you must enable the `bShouldUseTlsLibraries` flag on the `SocketIOClientComponent` **and** specify a `https` or `wss` URL as the host.
+
+Currently, certification verification is not implemented, so you must have `bShouldSkipCertificateVerification` enabled (currently the default). See [issue 303](https://github.com/getnamo/SocketIOClient-Unreal/issues/303).
 
 ## Packaging
 

--- a/Source/SocketIOClient/Private/SocketIOClient.cpp
+++ b/Source/SocketIOClient/Private/SocketIOClient.cpp
@@ -15,8 +15,8 @@ class FSocketIOClientModule : public ISocketIOClientModule
 {
 public:
 	//virtual TSharedPtr<FSocketIONative> NewValidNativePointer() override;
-	virtual TSharedPtr<FSocketIONative> NewValidNativePointer() override;
-	virtual TSharedPtr<FSocketIONative> ValidSharedNativePointer(FString SharedId) override;
+	virtual TSharedPtr<FSocketIONative> NewValidNativePointer(const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification) override;
+	virtual TSharedPtr<FSocketIONative> ValidSharedNativePointer(FString SharedId, const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification) override;
 	void ReleaseNativePointer(TSharedPtr<FSocketIONative> PointerToRelease) override;
 
 	/** IModuleInterface implementation */
@@ -79,9 +79,9 @@ void FSocketIOClientModule::ShutdownModule()
 	PluginNativePointers.Empty();
 }
 
-TSharedPtr<FSocketIONative> FSocketIOClientModule::NewValidNativePointer()
+TSharedPtr<FSocketIONative> FSocketIOClientModule::NewValidNativePointer(const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification)
 {
-	TSharedPtr<FSocketIONative> NewPointer = MakeShareable(new FSocketIONative);
+	TSharedPtr<FSocketIONative> NewPointer = MakeShareable(new FSocketIONative(bShouldUseTlsLibraries, bShouldSkipCertificateVerification));
 	
 	PluginNativePointers.Add(NewPointer);
 	
@@ -90,7 +90,7 @@ TSharedPtr<FSocketIONative> FSocketIOClientModule::NewValidNativePointer()
 	return NewPointer;
 }
 
-TSharedPtr<FSocketIONative> FSocketIOClientModule::ValidSharedNativePointer(FString SharedId)
+TSharedPtr<FSocketIONative> FSocketIOClientModule::ValidSharedNativePointer(FString SharedId, const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification)
 {
 	//Found key? return it
 	if (SharedNativePointers.Contains(SharedId))
@@ -100,7 +100,7 @@ TSharedPtr<FSocketIONative> FSocketIOClientModule::ValidSharedNativePointer(FStr
 	//Otherwise request a new id and return it
 	else
 	{
-		TSharedPtr<FSocketIONative> NewNativePtr = NewValidNativePointer();
+		TSharedPtr<FSocketIONative> NewNativePtr = NewValidNativePointer(bShouldUseTlsLibraries, bShouldSkipCertificateVerification);
 		SharedNativePointers.Add(SharedId, NewNativePtr);
 		AllSharedPtrs.Add(NewNativePtr);
 		return NewNativePtr;

--- a/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
+++ b/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
@@ -11,6 +11,8 @@
 
 USocketIOClientComponent::USocketIOClientComponent(const FObjectInitializer &init) : UActorComponent(init)
 {
+	bShouldUseTlsLibraries = false;
+	bShouldSkipCertificateVerification = false;
 	bShouldAutoConnect = true;
 	bWantsInitializeComponent = true;
 	bAutoActivate = true;
@@ -63,14 +65,14 @@ void USocketIOClientComponent::InitializeNative()
 {
 	if (bPluginScopedConnection)
 	{
-		NativeClient = ISocketIOClientModule::Get().ValidSharedNativePointer(PluginScopedId);
+		NativeClient = ISocketIOClientModule::Get().ValidSharedNativePointer(PluginScopedId, bShouldUseTlsLibraries, bShouldSkipCertificateVerification);
 
 		//Enforcement: This is the default FSocketIONative option value, but this component depends on it being true.
 		NativeClient->bCallbackOnGameThread = true;
 	}
 	else
 	{
-		NativeClient = ISocketIOClientModule::Get().NewValidNativePointer();
+		NativeClient = ISocketIOClientModule::Get().NewValidNativePointer(bShouldUseTlsLibraries, bShouldSkipCertificateVerification);
 	}
 
 	SetupCallbacks();

--- a/Source/SocketIOClient/Private/SocketIONative.cpp
+++ b/Source/SocketIOClient/Private/SocketIONative.cpp
@@ -9,7 +9,7 @@
 #include "sio_message.h"
 #include "sio_socket.h"
 
-FSocketIONative::FSocketIONative()
+FSocketIONative::FSocketIONative(const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification)
 {
 	PrivateClient = nullptr;
 	AddressAndPort = TEXT("http://localhost:3000");	//default to 127.0.0.1
@@ -20,7 +20,7 @@ FSocketIONative::FSocketIONative()
 	ReconnectionDelay = 5000;
 	bCallbackOnGameThread = true;
 
-	PrivateClient = MakeShareable(new sio::client);
+	PrivateClient = MakeShareable(new sio::client(bShouldUseTlsLibraries, bShouldSkipCertificateVerification));
 
 	ClearCallbacks();
 }

--- a/Source/SocketIOClient/Public/SocketIOClient.h
+++ b/Source/SocketIOClient/Public/SocketIOClient.h
@@ -35,12 +35,12 @@ public:
 	/** 
 	* Request a new plugin scoped pointer as a shared ptr.
 	*/
-	virtual TSharedPtr<FSocketIONative> NewValidNativePointer() { return nullptr; };
+	virtual TSharedPtr<FSocketIONative> NewValidNativePointer(const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification) { return nullptr; };
 
 	/** 
 	* Request a shared FSocketIONative instance for a given id. May allocate a new pointer.
 	*/
-	virtual TSharedPtr<FSocketIONative> ValidSharedNativePointer(FString SharedId) { return nullptr; };
+	virtual TSharedPtr<FSocketIONative> ValidSharedNativePointer(FString SharedId, const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification) { return nullptr; };
 
 	/** 
 	* Releases the given plugin scoped pointer using a background thread

--- a/Source/SocketIOClient/Public/SocketIOClientComponent.h
+++ b/Source/SocketIOClient/Public/SocketIOClientComponent.h
@@ -60,9 +60,29 @@ public:
 	FSIOCEventSignature OnFail;
 
 
-	/** Default connection address string in form e.g. http://localhost:80. */
+	/**
+		* Default connection address string in form e.g. http://localhost:80.
+		* If HTTPS/WSS is provided and TLS/SSL libraries aren't compiled, HTTP/WS
+		* will be used.
+		*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SocketIO Connection Properties")
 	FString AddressAndPort;
+
+	/**
+		* Whether or not to use the TLS/SSL libraries for the connection.
+		* Ignored if TLS/SSL libraries are not compiled in (SIO_TLS isn't defined)
+		*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SocketIO Connection Properties")
+	bool bShouldUseTlsLibraries;
+
+	/**
+		* If `Should Use TLS Libraries` is set to true, setting this to true
+		* will not verify the authenticity of the SSL certificate (i.e. asio::ssl::verify_none).
+		* NOTE: Certification verification is currently not implemented; setting to false will
+		* always fail verification.
+		*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SocketIO Connection Properties")
+	bool bShouldSkipCertificateVerification = true;
 
 	/** If true will auto-connect on begin play to address specified in AddressAndPort. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SocketIO Connection Properties")

--- a/Source/SocketIOClient/Public/SocketIONative.h
+++ b/Source/SocketIOClient/Public/SocketIONative.h
@@ -95,7 +95,7 @@ public:
 	/** If true, all callbacks and events will occur on game thread. Default true. */
 	bool bCallbackOnGameThread;
 
-	FSocketIONative();
+	FSocketIONative(const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification);
 
 	/**
 	* Connect to a socket.io server, optional method if auto-connect is set to true.

--- a/Source/SocketIOLib/Private/internal/sio_client_impl.h
+++ b/Source/SocketIOLib/Private/internal/sio_client_impl.h
@@ -40,20 +40,28 @@
 
 #if defined(DEBUG)
   #if SIO_TLS
-	#include <websocketpp/config/debug_asio.hpp>
-	typedef websocketpp::config::debug_asio_tls client_config;
-  #else
+    #define UI UI_ST
+    THIRD_PARTY_INCLUDES_START
+    #include "openssl/hmac.h"
+    #include <websocketpp/config/debug_asio.hpp>
+    typedef websocketpp::config::debug_asio_tls client_config_tls;
+    THIRD_PARTY_INCLUDES_END
+    #undef UI
+  #endif //SIO_TLS
 	#include <websocketpp/config/debug_asio_no_tls.hpp>
 	typedef websocketpp::config::debug_asio client_config;
-  #endif //SIO_TLS
 #else
   #if SIO_TLS
-	#include <websocketpp/config/asio_client.hpp>
-	typedef websocketpp::config::asio_tls_client client_config;
-  #else
+    #define UI UI_ST
+    THIRD_PARTY_INCLUDES_START
+    #include "openssl/hmac.h"
+    #include <websocketpp/config/asio_client.hpp>
+    typedef websocketpp::config::asio_tls_client client_config_tls;
+    THIRD_PARTY_INCLUDES_END
+    #undef UI
+  #endif //SIO_TLS
 	#include <websocketpp/config/asio_no_tls_client.hpp>
 	typedef websocketpp::config::asio_client client_config;
-  #endif //SIO_TLS
 #endif //DEBUG
 #include <asio/deadline_timer.hpp>
 
@@ -72,11 +80,14 @@
     {
         using namespace websocketpp;
 
-        typedef websocketpp::client<client_config> client_type;
+        typedef websocketpp::client<client_config> client_type_no_tls;
+#if SIO_TLS
+        typedef websocketpp::client<client_config_tls> client_type_tls;
+#endif
 
-        class client_impl {
+        class client_impl_base {
 
-        protected:
+        public:
             enum con_state
             {
                 con_opening,
@@ -85,185 +96,235 @@
                 con_closed
             };
 
-            client_impl();
+            client_impl_base() {}
+            virtual void template_init() {};
 
-            ~client_impl();
+            virtual ~client_impl_base() {}
 
-            //set listeners and event bindings.
+            // listeners and event bindings. (see SYNTHESIS_SETTER below)
+            virtual void set_open_listener(client::con_listener const&) {};
+            virtual void set_fail_listener(client::con_listener const&) {};
+            virtual void set_reconnect_listener(client::reconnect_listener const&) {};
+            virtual void set_reconnecting_listener(client::con_listener const&) {};
+            virtual void set_close_listener(client::close_listener const&) {};
+            virtual void set_socket_open_listener(client::socket_listener const&) {};
+            virtual void set_socket_close_listener(client::socket_listener const&) {};
+
+            // used by sio::client
+            virtual void clear_con_listeners() {};
+            virtual void clear_socket_listeners() {};
+            virtual void connect(const string& uri, const map<string, string>& query, const map<string, string>& headers, const std::string& path = "socket.io") {};
+
+            virtual sio::socket::ptr const& socket(const std::string& nsp) = 0;
+            virtual void close() {};
+            virtual void sync_close() {};
+            virtual bool opened() const { return false; };
+            virtual std::string const& get_sessionid() const = 0;
+            virtual void set_reconnect_attempts(unsigned attempts) {};
+            virtual void set_reconnect_delay(unsigned millis) {};
+            virtual void set_reconnect_delay_max(unsigned millis) {};
+
+            // used by sio::socket
+            virtual void send(packet& p) {};
+            virtual void remove_socket(std::string const& nsp) {};
+            virtual asio::io_service& get_io_service() = 0;
+            virtual void on_socket_closed(std::string const& nsp) {};
+            virtual void on_socket_opened(std::string const& nsp) {};
+
+            virtual void set_logs_default() {};
+            virtual void set_logs_quiet() {};
+            virtual void set_logs_verbose() {};
+
+            virtual std::string const& get_current_url() const = 0;
+
+            // used for selecting whether or not to use TLS
+            static bool is_tls(const std::string& uri);
+
+#if SIO_TLS
+            virtual void set_verify_mode(int mode) {};
+#endif
+
+        protected:
+            // Wrap protected member functions of sio::socket because only client_impl_base is friended.
+            sio::socket* new_socket(std::string const&);
+            void socket_on_message_packet(sio::socket::ptr&, packet const&);
+            typedef void (sio::socket::* socket_void_fn)(void);
+            inline socket_void_fn socket_on_close() { return &sio::socket::on_close; }
+            inline socket_void_fn socket_on_disconnect() { return &sio::socket::on_disconnect; }
+            inline socket_void_fn socket_on_open() { return &sio::socket::on_open; }
+        };
+
+    template<typename client_type>
+    class client_impl : public client_impl_base {
+    public:
+        typedef typename client_type::message_ptr message_ptr;
+
+        client_impl();
+        void template_init() override; // template-specific initialization
+
+        ~client_impl();
+
+        //set listeners and event bindings.
+        void connect(const std::string& uri, const std::map<std::string, std::string>& queryString,
+            const std::map<std::string, std::string>& httpExtraHeaders, const std::string& path = "socket.io");
+
+        sio::socket::ptr const& socket(const std::string& nsp);
+
+        // Closes the connection
+        void close();
+
+        void sync_close();
+
+        bool opened() const { return m_con_state == con_opened; }
+
+        std::string const& get_sessionid() const { return m_sid; }
+
+        std::string const& get_current_url() const { return m_base_url; }
+
+        void set_reconnect_attempts(unsigned attempts) { m_reconn_attempts = attempts; }
+
+        void set_reconnect_delay(unsigned millis) { m_reconn_delay = millis; if (m_reconn_delay_max < millis) m_reconn_delay_max = millis; }
+
+        void set_reconnect_delay_max(unsigned millis) { m_reconn_delay_max = millis; if (m_reconn_delay > millis) m_reconn_delay = millis; }
+
+        void set_logs_default();
+
+        void set_logs_quiet();
+
+        void set_logs_verbose();
+
 #define SYNTHESIS_SETTER(__TYPE__,__FIELD__) \
-    void set_##__FIELD__(__TYPE__ const& l) \
-        { m_##__FIELD__ = l;}
+        void set_##__FIELD__(__TYPE__ const& l) \
+            { m_##__FIELD__ = l;}
 
             SYNTHESIS_SETTER(client::con_listener, open_listener)
 
-                SYNTHESIS_SETTER(client::con_listener, fail_listener)
+            SYNTHESIS_SETTER(client::con_listener, fail_listener)
 
-                SYNTHESIS_SETTER(client::reconnect_listener, reconnect_listener)
+            SYNTHESIS_SETTER(client::reconnect_listener, reconnect_listener)
 
-                SYNTHESIS_SETTER(client::con_listener, reconnecting_listener)
+            SYNTHESIS_SETTER(client::con_listener, reconnecting_listener)
 
-                SYNTHESIS_SETTER(client::close_listener, close_listener)
+            SYNTHESIS_SETTER(client::close_listener, close_listener)
 
-                SYNTHESIS_SETTER(client::socket_listener, socket_open_listener)
+            SYNTHESIS_SETTER(client::socket_listener, socket_open_listener)
 
-                SYNTHESIS_SETTER(client::socket_listener, socket_close_listener)
-
+            SYNTHESIS_SETTER(client::socket_listener, socket_close_listener)
 #undef SYNTHESIS_SETTER
 
-
-                void clear_con_listeners()
-            {
-                m_open_listener = nullptr;
-                m_close_listener = nullptr;
-                m_fail_listener = nullptr;
-                m_reconnect_listener = nullptr;
-                m_reconnecting_listener = nullptr;
-            }
-
-            void clear_socket_listeners()
-            {
-                m_socket_open_listener = nullptr;
-                m_socket_close_listener = nullptr;
-            }
-
-            // Client Functions - such as send, etc.
-            void connect(const std::string& uri, const std::map<std::string, std::string>& queryString,
-                const std::map<std::string, std::string>& httpExtraHeaders, const std::string& path = "socket.io");
-
-            sio::socket::ptr const& socket(const std::string& nsp);
-
-            // Closes the connection
-            void close();
-
-            void sync_close();
-
-            bool opened() const { return m_con_state == con_opened; }
-
-            std::string const& get_sessionid() const { return m_sid; }
-
-            std::string const& get_current_url() const { return m_base_url; }
-
-            void set_reconnect_attempts(unsigned attempts) { m_reconn_attempts = attempts; }
-
-            void set_reconnect_delay(unsigned millis) { m_reconn_delay = millis; if (m_reconn_delay_max < millis) m_reconn_delay_max = millis; }
-
-            void set_reconnect_delay_max(unsigned millis) { m_reconn_delay_max = millis; if (m_reconn_delay > millis) m_reconn_delay = millis; }
-
-            void set_logs_default();
-
-            void set_logs_quiet();
-
-            void set_logs_verbose();
-
-        protected:
-            void send(packet& p);
-
-            void remove_socket(std::string const& nsp);
-
-            asio::io_service& get_io_service();
-
-            void on_socket_closed(std::string const& nsp);
-
-            void on_socket_opened(std::string const& nsp);
-
-        private:
-            void run_loop();
-
-            void connect_impl(const std::string& uri, const std::string& query);
-
-            void close_impl(close::status::value const& code, std::string const& reason);
-
-            void send_impl(std::shared_ptr<const std::string> const& payload_ptr, frame::opcode::value opcode);
-
-            void ping(const asio::error_code& ec);
-
-            void timeout_pong(const asio::error_code& ec);
-
-            void timeout_reconnect(asio::error_code const& ec);
-
-            unsigned next_delay() const;
-
-            socket::ptr get_socket_locked(std::string const& nsp);
-
-            void sockets_invoke_void(void (sio::socket::* fn)(void));
-
-            void on_decode(packet const& pack);
-            void on_encode(bool isBinary, shared_ptr<const string> const& payload);
-
-            //websocket callbacks
-            void on_fail(connection_hdl con);
-
-            void on_open(connection_hdl con);
-
-            void on_close(connection_hdl con);
-
-            void on_message(connection_hdl con, client_type::message_ptr msg);
-
-            //socketio callbacks
-            void on_handshake(message::ptr const& message);
-
-            void on_ping();
-
-            void reset_states();
-
-            void clear_timers();
-
 #if SIO_TLS
-            typedef websocketpp::lib::shared_ptr<asio::ssl::context> context_ptr;
-
-            context_ptr on_tls_init(connection_hdl con);
+        void set_verify_mode(int mode) override;
 #endif
 
-            // Percent encode query string
-            std::string encode_query_string(const std::string& query);
+    public:
+        void send(packet& p);
 
-            // Connection pointer for client functions.
-            connection_hdl m_con;
-            client_type m_client;
-            // Socket.IO server settings
-            std::string m_sid;
-            std::string m_base_url;
-            std::string m_query_string;
-            std::map<std::string, std::string> m_http_headers;
+        void remove_socket(std::string const& nsp);
 
-            unsigned int m_ping_interval;
-            unsigned int m_ping_timeout;
+        asio::io_service& get_io_service();
 
-            std::unique_ptr<std::thread> m_network_thread;
+        void on_socket_closed(std::string const& nsp);
 
-            packet_manager m_packet_mgr;
+        void on_socket_opened(std::string const& nsp);
 
-            std::unique_ptr<asio::steady_timer> m_ping_timeout_timer;
+    private:
+        void run_loop();
 
-            std::unique_ptr<asio::steady_timer> m_reconn_timer;
+        void connect_impl(const std::string& uri, const std::string& query);
 
-            con_state m_con_state;
+        void close_impl(close::status::value const& code, std::string const& reason);
 
-            client::con_listener m_open_listener;
-            client::con_listener m_fail_listener;
-            client::con_listener m_reconnecting_listener;
-            client::reconnect_listener m_reconnect_listener;
-            client::close_listener m_close_listener;
+        void send_impl(std::shared_ptr<const std::string> const& payload_ptr, frame::opcode::value opcode);
 
-            client::socket_listener m_socket_open_listener;
-            client::socket_listener m_socket_close_listener;
+        void ping(const asio::error_code& ec);
 
-            std::map<const std::string, socket::ptr> m_sockets;
+        void timeout_pong(const asio::error_code& ec);
 
-            std::mutex m_socket_mutex;
+        void timeout_reconnect(asio::error_code const& ec);
 
-            unsigned m_reconn_delay;
+        unsigned next_delay() const;
 
-            unsigned m_reconn_delay_max;
+        socket::ptr get_socket_locked(std::string const& nsp);
 
-            unsigned m_reconn_attempts;
+        void sockets_invoke_void(void (sio::socket::* fn)(void));
 
-            unsigned m_reconn_made;
+        void on_decode(packet const& pack);
+        void on_encode(bool isBinary, shared_ptr<const string> const& payload);
 
-            std::string m_path;
+        //websocket callbacks
+        void on_fail(connection_hdl con);
 
-            friend class sio::client;
-            friend class sio::socket;
-        };
-    }
+        void on_open(connection_hdl con);
+
+        void on_close(connection_hdl con);
+
+        void on_message(connection_hdl con, message_ptr msg);
+
+        //socketio callbacks
+        void on_handshake(message::ptr const& message);
+
+        void on_ping();
+
+        void reset_states();
+
+        void clear_timers();
+
+        // Percent encode query string
+        std::string encode_query_string(const std::string& query);
+
+        // Connection pointer for client functions.
+        connection_hdl m_con;
+        client_type m_client;
+
+        // Socket.IO server settings
+        std::string m_sid;
+        std::string m_base_url;
+        std::string m_query_string;
+        std::map<std::string, std::string> m_http_headers;
+
+        unsigned int m_ping_interval;
+        unsigned int m_ping_timeout;
+
+        std::unique_ptr<std::thread> m_network_thread;
+
+        packet_manager m_packet_mgr;
+
+        std::unique_ptr<asio::steady_timer> m_ping_timeout_timer;
+
+        std::unique_ptr<asio::steady_timer> m_reconn_timer;
+
+        con_state m_con_state;
+
+        client::con_listener m_open_listener;
+        client::con_listener m_fail_listener;
+        client::con_listener m_reconnecting_listener;
+        client::reconnect_listener m_reconnect_listener;
+        client::close_listener m_close_listener;
+
+        client::socket_listener m_socket_open_listener;
+        client::socket_listener m_socket_close_listener;
+
+        std::map<const std::string, socket::ptr> m_sockets;
+
+        std::mutex m_socket_mutex;
+
+        unsigned m_reconn_delay;
+
+        unsigned m_reconn_delay_max;
+
+        unsigned m_reconn_attempts;
+
+        unsigned m_reconn_made;
+
+        //passthrough path of plugin
+        std::string m_path;
+
+#if SIO_TLS
+        int verify_mode = -1;
+#endif
+
+        friend class sio::client;
+        friend class sio::socket;
+    };
+}
 #endif // SIO_CLIENT_IMPL_H

--- a/Source/SocketIOLib/Private/sio_socket.cpp
+++ b/Source/SocketIOLib/Private/sio_socket.cpp
@@ -131,7 +131,7 @@ namespace sio
     {
     public:
         
-        impl(client_impl *,std::string const&);
+        impl(client_impl_base *,std::string const&);
         ~impl();
         
         void on(std::string const& event_name,event_listener_aux const& func);
@@ -192,7 +192,7 @@ namespace sio
         
         static unsigned int s_global_event_id;
         
-        sio::client_impl *m_client;
+        sio::client_impl_base *m_client;
         
         bool m_connected;
         std::string m_nsp;
@@ -251,7 +251,7 @@ namespace sio
         m_error_listener = nullptr;
     }
     
-    socket::impl::impl(client_impl *client,std::string const& nsp):
+    socket::impl::impl(client_impl_base *client,std::string const& nsp):
         m_client(client),
         m_connected(false),
         m_nsp(nsp)
@@ -348,7 +348,7 @@ namespace sio
     void socket::impl::on_close()
     {
         NULL_GUARD(m_client);
-        sio::client_impl *client = m_client;
+        sio::client_impl_base *client = m_client;
         m_client = NULL;
 
         if(m_connection_timer)
@@ -546,7 +546,7 @@ namespace sio
         return socket::event_listener();
     }
     
-    socket::socket(client_impl* client,std::string const& nsp):
+    socket::socket(client_impl_base* client,std::string const& nsp):
         m_impl(new impl(client,nsp))
     {
     }

--- a/Source/SocketIOLib/Public/sio_client.h
+++ b/Source/SocketIOLib/Public/sio_client.h
@@ -14,7 +14,7 @@
 
 namespace sio
 {
-    class client_impl;
+    class client_impl_base;
     
     class SOCKETIOLIB_API client {
     public:
@@ -33,6 +33,9 @@ namespace sio
         typedef std::function<void(std::string const& nsp)> socket_listener;
         
         client();
+
+        client(const bool bShouldUseTlsLibraries, const bool bShouldSkipCertificateVerification);
+
         ~client();
         
         //set listeners and event bindings.
@@ -55,6 +58,9 @@ namespace sio
         void clear_socket_listeners();
         
         // Client Functions - such as send, etc.
+
+        void connect();
+
         void connect(const std::string& uri);
 
         void connect(const std::string& uri, const std::map<std::string,std::string>& query);
@@ -97,7 +103,7 @@ namespace sio
         client(client const&){}
         void operator=(client const&){}
         
-        client_impl* m_impl;
+        client_impl_base* m_impl;
 
         std::string m_path;
     };

--- a/Source/SocketIOLib/Public/sio_socket.h
+++ b/Source/SocketIOLib/Public/sio_socket.h
@@ -41,7 +41,7 @@ namespace sio
         friend class event_adapter;
     };
     
-    class client_impl;
+    class client_impl_base;
     class packet;
     
     //The name 'socket' is taken from concept of official socket.io.
@@ -76,8 +76,9 @@ namespace sio
         
         std::string const& get_namespace() const;
         
+        socket(client_impl_base*,std::string const&);
+
     protected:
-        socket(client_impl*,std::string const&);
 
         void on_connected();
         
@@ -89,7 +90,7 @@ namespace sio
         
         void on_message_packet(packet const& p);
         
-        friend class client_impl;
+        friend class client_impl_base;
         
     private:
         //disable copy constructor and assign operator.

--- a/Source/SocketIOLib/SocketIOLib.Build.cs
+++ b/Source/SocketIOLib/SocketIOLib.Build.cs
@@ -9,56 +9,68 @@ namespace UnrealBuildTool.Rules
 	public class SocketIOLib : ModuleRules
 	{
 		private string ThirdPartyPath
-        {
-            get { return Path.GetFullPath(Path.Combine(ModuleDirectory, "../ThirdParty/")); }
-        }
+		{
+			get { return Path.GetFullPath(Path.Combine(ModuleDirectory, "../ThirdParty/")); }
+		}
 
-	    public SocketIOLib(ReadOnlyTargetRules Target) : base(Target)
-	    {
-			PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-			bUseRTTI = true;
-			bEnableExceptions = true;
+			public SocketIOLib(ReadOnlyTargetRules Target) : base(Target)
+			{
+				PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+				bUseRTTI = true;
+				bEnableExceptions = true;
 
-			PublicIncludePaths.AddRange(
-	            new string[] {
-					Path.Combine(ModuleDirectory, "Public"),
-	            }
-	            );
-
-
-	        PrivateIncludePaths.AddRange(
-	            new string[] {
-					Path.Combine(ModuleDirectory, "Private"),
-					Path.Combine(ModuleDirectory, "Private/internal"),
-					Path.Combine(ThirdPartyPath, "websocketpp"),
-					Path.Combine(ThirdPartyPath, "asio/asio/include"),
-					Path.Combine(ThirdPartyPath, "rapidjson/include"),
-	            }
-	            );
+				PublicIncludePaths.AddRange(
+					new string[] {
+						Path.Combine(ModuleDirectory, "Public"),
+					}
+				);
 
 
-	        PublicDependencyModuleNames.AddRange(
-	            new string[]
-	            {
-	            "Core",
-	            }
-	            );
+				PrivateIncludePaths.AddRange(
+					new string[] {
+						Path.Combine(ModuleDirectory, "Private"),
+						Path.Combine(ModuleDirectory, "Private/internal"),
+						Path.Combine(ThirdPartyPath, "websocketpp"),
+						Path.Combine(ThirdPartyPath, "asio/asio/include"),
+						Path.Combine(ThirdPartyPath, "rapidjson/include"),
+					}
+				);
 
 
-	        PrivateDependencyModuleNames.AddRange(
-	            new string[]
-	            {
-	            "CoreUObject",
-	            "Engine",
-	            }
-	            );
+				PublicDependencyModuleNames.AddRange(
+					new string[]
+					{
+						"Core",
+					}
+				);
 
 
-	        DynamicallyLoadedModuleNames.AddRange(
-	            new string[]
-	            {
-	            }
-	            );
-	    }
+				PrivateDependencyModuleNames.AddRange(
+					new string[]
+					{
+						"CoreUObject",
+						"Engine",
+						"OpenSSL"
+					}
+				);
+
+
+				DynamicallyLoadedModuleNames.AddRange(
+					new string[]
+					{
+					}
+				);
+
+				//Setup TLS support | Maybe other platforms work as well (untested)
+				if (
+					Target.Platform == UnrealTargetPlatform.Win64 ||
+					Target.Platform == UnrealTargetPlatform.Mac ||
+					Target.Platform == UnrealTargetPlatform.Linux ||
+					Target.Platform == UnrealTargetPlatform.IOS
+				)
+				{
+					PublicDefinitions.Add("SIO_TLS=1");
+				}
+			}
 	}
 }


### PR DESCRIPTION
This PR is a combination of work from @dobby5, @joelnordell, @getnamo, and myself to add TLS/SSL support. Thanks everyone for their work and support! Unfortunately due to a lot of whitespace changes and merge conflicts, this PR removed individual commits in favor of a simple squashed commit without the majority of the whitespace changes.

With this PR:
- Fixes #39
- TLS/SSL support works without recompiling to turn it on/off. You compile once with `SIO_TLS=1` (enabled with this PR), and users can easily enable/disable the TLS functionality with a boolean flag
- Due to the structure of the classes and their various usages, to use TLS/SSL, a user must enable `bShouldUseTlsLibraries` on the `SocketIOClientComponent`. It was tricky to implement a smart detection based off the host's scheme (`http` vs `https` / `ws` vs `wss`) due to the class initialization and connection flexibility.
- Certificate verification is **not implemented**, but the foundation of adding support has been added with the idea that the user must specify the CA Chain (perhaps via a file path or copy/paste the whole chain contents in a string field). https://github.com/getnamo/SocketIOClient-Unreal/issues/303 will track implementation of this feature. Implementation is not on my personal near-term roadmap (but likely one day)
- The new TLS/SSL requirements bumps up the recommended socket.io server version from `1.4+` to `3.0+`. A compatibility table was added to properly document what versions of the plugin work with which socket.io server versions. @getnamo should update `README.md`, line 48 to reflect the actual version this change gets published in.

If requested, I can provide a NodeJS script that can be used for testing purposes.