### PR TITLE
Update SocketIONative.cpp

### DIFF
--- a/Source/SocketIOClient/Private/SocketIONative.cpp
+++ b/Source/SocketIOClient/Private/SocketIONative.cpp
@@ -34,7 +34,7 @@ void FSocketIONative::Connect(const FString& InAddressAndPort, const TSharedPtr<
 	}
 
 	//Connect to the server on a background thread so it never blocks
-	FCULambdaRunnable::RunLambdaOnBackGroundThread([&, StdAddressString, Query, Headers]
+	FCULambdaRunnable::RunLambdaOnBackGroundThread([&, StdAddressString, Query, Headers, Path]
 	{
 		std::map<std::string, std::string> QueryMap = {};
 		std::map<std::string, std::string> HeadersMap = {};


### PR DESCRIPTION
The absence of the Path variable caused a nullpointer reference error once every couple of times on the background thread.