### PR TITLE
Non-Windows support: fix case for HAL/PlatformFileManager.h

### DIFF
--- a/Source/CoreUtility/Private/CUFileComponent.cpp
+++ b/Source/CoreUtility/Private/CUFileComponent.cpp
@@ -2,7 +2,7 @@
 
 
 #include "CUFileComponent.h"
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 


### PR DESCRIPTION
This PR fixes the casing for `HAL/PlatformFileManager.h` to support non-Windows targets