### PR TITLE
Fix issue with std::result_of being removed in c++20

### DIFF
--- a/Source/SocketIOLib/SocketIOLib.Build.cs
+++ b/Source/SocketIOLib/SocketIOLib.Build.cs
@@ -72,6 +72,14 @@ namespace UnrealBuildTool.Rules
 				{
 					PublicDefinitions.Add("SIO_TLS=1");
 				}
+				
+				if (
+					(Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 3) ||
+					Target.Version.MajorVersion > 5
+				)
+				{
+					PublicDefinitions.Add("ASIO_HAS_STD_INVOKE_RESULT=1");
+				}
 			}
 	}
 }


### PR DESCRIPTION
This PR fixes #392 by adding a define to tell asio to use `std::invoke_result` instead of `std::result_of`; you can see the third party reference to these here: https://github.com/chriskohlhoff/asio/blob/master/asio/include/asio/detail/type_traits.hpp#L90-L96

IIRC I did not have issues compiling for Linux on 5.2.1, so I believe the new clang16 toolchain is defaulting to a c++ standard that  removed `std::result_of`.