### PR TITLE
Add support for 5.4

### DIFF
--- a/Source/CoreUtility/CoreUtility.Build.cs
+++ b/Source/CoreUtility/CoreUtility.Build.cs
@@ -46,6 +46,17 @@ public class CoreUtility : ModuleRules
             );
 
 
+        if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 4)
+        {
+            PrivateDependencyModuleNames.AddRange(
+                new string[]
+                {
+                    "OpusAudioDecoder",
+                }
+            );
+        }
+
+
         DynamicallyLoadedModuleNames.AddRange(
             new string[]
             {

--- a/Source/CoreUtility/Private/CUBlueprintLibrary.cpp
+++ b/Source/CoreUtility/Private/CUBlueprintLibrary.cpp
@@ -10,7 +10,11 @@
 #include "HAL/ThreadSafeBool.h"
 #include "RHI.h"
 #include "Misc/FileHelper.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+#include "Decoders/OpusAudioInfo.h"
+#else
 #include "OpusAudioInfo.h"
+#endif
 #include "Runtime/Launch/Resources/Version.h"
 #include "Developer/TargetPlatform/Public/Interfaces/IAudioFormat.h"
 #include "CoreMinimal.h"

--- a/Source/CoreUtility/Private/CUOpusCoder.cpp
+++ b/Source/CoreUtility/Private/CUOpusCoder.cpp
@@ -109,7 +109,7 @@ bool FCUOpusCoder::EncodeStream(const TArray<uint8>& InPCMBytes, FCUOpusMinimalS
 
 		if (EncodedBytes < 0)
 		{
-			UE_LOG(LogTemp, Warning, TEXT("opus_encode err: %s"), opus_strerror(EncodedBytes));
+			UE_LOG(LogTemp, Warning, TEXT("opus_encode err: %hs"), opus_strerror(EncodedBytes));
 			return false;
 		}
 		OutStream.CompressedBytes.Append(TempBuffer.GetData(), EncodedBytes);
@@ -164,7 +164,7 @@ bool FCUOpusCoder::DecodeStream(const FCUOpusMinimalStream& InStream, TArray<uin
 		}
 		else if (DecodedSamples < 0)
 		{
-			UE_LOG(LogTemp, Log, TEXT("%s"), opus_strerror(DecodedSamples));
+			UE_LOG(LogTemp, Log, TEXT("%hs"), opus_strerror(DecodedSamples));
 			return false;
 		}
 
@@ -228,16 +228,18 @@ int32 FCUOpusCoder::EncodeFrame(const TArray<uint8>& InPCMFrame, TArray<uint8>& 
 {
 #if WITH_OPUS
 	return opus_encode(Encoder, (const opus_int16*)InPCMFrame.GetData(), FrameSize, OutCompressed.GetData(), MaxPacketSize);
-#endif
+#else
 	return 0;
+#endif
 }
 
 int32 FCUOpusCoder::DecodeFrame(const TArray<uint8>& InCompressedFrame, TArray<uint8>& OutPCMFrame)
 {
 #if WITH_OPUS
 	return opus_decode(Decoder, InCompressedFrame.GetData(), InCompressedFrame.Num(), (opus_int16*)OutPCMFrame.GetData(), FrameSize, 0);
-#endif
+#else
 	return 0;
+#endif
 }
 
 


### PR DESCRIPTION
This PR adds support for 5.4; the plugin won't compile without these changes. I believe (but haven't tested) these are back-compatible with older versions.