### PR TITLE
Missing includes for strict non-unity build

### DIFF
--- a/Source/CoreUtility/Public/CUOpusCoder.h
+++ b/Source/CoreUtility/Public/CUOpusCoder.h
@@ -1,6 +1,9 @@
 // Copyright 2019-current Getnamo. All Rights Reserved
 
 #pragma once
+
+#include "CoreMinimal.h"
+
 #define WITH_OPUS (PLATFORM_WINDOWS || PLATFORM_UNIX || PLATFORM_ANDROID)
 
 #if WITH_OPUS

--- a/Source/CoreUtility/Public/ICoreUtility.h
+++ b/Source/CoreUtility/Public/ICoreUtility.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-
-DECLARE_LOG_CATEGORY_EXTERN(CoreUtilityLog, Log, All);
+#include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(CoreUtilityLog, Log, All);
 
 /**
 * The public interface to this module.  In most cases, this interface is only public to sibling modules

--- a/Source/SIOJson/Private/SIOJLibrary.cpp
+++ b/Source/SIOJson/Private/SIOJLibrary.cpp
@@ -11,6 +11,7 @@
 #include "SIOJsonObject.h"
 #include "Misc/Base64.h"
 #include "Engine/Engine.h"
+#include "Serialization/JsonSerializer.h"
 
 //////////////////////////////////////////////////////////////////////////
 // Helpers

--- a/Source/SIOJson/Private/SIOJRequestJSON.cpp
+++ b/Source/SIOJson/Private/SIOJRequestJSON.cpp
@@ -8,6 +8,8 @@
 #include "SIOJLibrary.h"
 #include "SIOJsonValue.h"
 #include "SIOJsonObject.h"
+#include "Engine/Engine.h"
+#include "Serialization/JsonSerializer.h"
 
 template <class T> void FSIOJLatentAction<T>::Cancel()
 {


### PR DESCRIPTION
Partial fix for non-unity builds with strict includes as mentioned in issue #419 