### PR TITLE
Add struct <-> binary serialization; ~5x Faster than json de/serializ…

### DIFF
--- a/Source/CoreUtility/Public/CUBlueprintLibrary.h
+++ b/Source/CoreUtility/Public/CUBlueprintLibrary.h
@@ -174,4 +174,20 @@ public:
 	*/
 	UFUNCTION(BlueprintCallable, Category = "CoreUtility|Threading", meta = (Latent, LatentInfo = "LatentInfo", WorldContext = "WorldContextObject"))
 	static void CallFunctionOnThreadGraphReturn(const FString& Function, ESIOCallbackType ThreadType, struct FLatentActionInfo LatentInfo, UObject* WorldContextObject = nullptr);
+
+
+	UFUNCTION(BlueprintCallable, Category = "SocketIOFunctions", CustomThunk, meta = (CustomStructureParam = "AnyStruct"))
+	static bool StructToBytes(TFieldPath<FProperty> AnyStruct, TArray<uint8>& OutBytes);
+
+	DECLARE_FUNCTION(execStructToBytes);
+	
+
+	UFUNCTION(BlueprintCallable, Category = "SocketIOFunctions", CustomThunk, meta = (CustomStructureParam = "OutAnyStruct"))
+	static bool BytesToStruct(const TArray<uint8>& InBytes, TFieldPath<FProperty> OutAnyStruct);
+
+	DECLARE_FUNCTION(execBytesToStruct);
+
+	//C++ binary utility
+	static bool SerializeStruct(UStruct* Struct, void* StructPtr, TArray<uint8>& OutBytes);
+	static bool DeserializeStruct(UStruct* Struct, void* StructPtr, const TArray<uint8>& InBytes);
 };

--- a/Source/SIOJson/Private/SIOJConvert.cpp
+++ b/Source/SIOJson/Private/SIOJConvert.cpp
@@ -12,6 +12,7 @@
 #include "JsonObjectConverter.h"
 #include "UObject/PropertyPortFlags.h"
 #include "Misc/Base64.h"
+#include "Serialization/MemoryWriter.h"
 
 typedef TJsonWriterFactory< TCHAR, TCondensedJsonPrintPolicy<TCHAR> > FCondensedJsonStringWriterFactory;
 typedef TJsonWriter< TCHAR, TCondensedJsonPrintPolicy<TCHAR> > FCondensedJsonStringWriter;
@@ -847,7 +848,6 @@ bool USIOJConvert::JsonFileToUStruct(const FString& FilePath, UStruct* Struct, v
 	//Read into struct
 	return JsonObjectToUStruct(ToJsonObject(JsonString), Struct, StructPtr, IsBlueprintStruct);
 }
-
 
 bool USIOJConvert::ToJsonFile(const FString& FilePath, UStruct* Struct, void* StructPtr, bool IsBlueprintStruct /*= false*/)
 {

--- a/Source/SIOJson/Public/SIOJConvert.h
+++ b/Source/SIOJson/Public/SIOJConvert.h
@@ -46,8 +46,7 @@ public:
 	
 	//Files - convenience read/write files
 	static bool JsonFileToUStruct(const FString& FilePath, UStruct* Struct, void* StructPtr, bool IsBlueprintStruct = false);
-	static bool ToJsonFile(const FString& FilePath, UStruct* Struct, void* StructPtr, bool IsBlueprintStruct = false);
-		
+	static bool ToJsonFile(const FString& FilePath, UStruct* Struct, void* StructPtr, bool IsBlueprintStruct = false);		
 
 	//typically from callbacks
 	static class USIOJsonValue* ToSIOJsonValue(const TArray<TSharedPtr<FJsonValue>>& JsonValueArray);


### PR DESCRIPTION
Uses Unreal's archiving system to serialize/deserialize arbitrary structs, exposed to blueprint using wildcard fieldpath capture. If speed is primary focus and without the interpretability of json string, then this method is superior for that use case.