### PR TITLE
Add `TryGet...` methods to USIOJsonObject

### DIFF
--- a/Source/SIOJson/Private/SIOJsonObject.cpp
+++ b/Source/SIOJson/Private/SIOJsonObject.cpp
@@ -163,6 +163,11 @@ void USIOJsonObject::SetField(const FString& FieldName, USIOJsonValue* JsonValue
 //////////////////////////////////////////////////////////////////////////
 // FJsonObject API Helpers (easy to use with simple Json objects)
 
+bool USIOJsonObject::TryGetNumberField(const FString& FieldName, float& OutNumber) const
+{
+	return JsonObj.IsValid() && JsonObj->TryGetNumberField(FieldName, OutNumber);
+}
+
 float USIOJsonObject::GetNumberField(const FString& FieldName) const
 {
 	if (!JsonObj.IsValid() || !JsonObj->HasTypedField<EJson::Number>(FieldName))
@@ -184,6 +189,12 @@ void USIOJsonObject::SetNumberField(const FString& FieldName, float Number)
 	JsonObj->SetNumberField(FieldName, Number);
 }
 
+
+bool USIOJsonObject::TryGetStringField(const FString& FieldName, FString& OutString) const
+{
+	return JsonObj.IsValid() && JsonObj->TryGetStringField(FieldName, OutString);
+}
+
 FString USIOJsonObject::GetStringField(const FString& FieldName) const
 {
 	if (!JsonObj.IsValid() || !JsonObj->HasTypedField<EJson::String>(FieldName))
@@ -203,6 +214,11 @@ void USIOJsonObject::SetStringField(const FString& FieldName, const FString& Str
 	}
 
 	JsonObj->SetStringField(FieldName, StringValue);
+}
+
+bool USIOJsonObject::TryGetBoolField(const FString& FieldName, bool& OutBool) const
+{
+	return JsonObj.IsValid() && JsonObj->TryGetBoolField(FieldName, OutBool);
 }
 
 bool USIOJsonObject::GetBoolField(const FString& FieldName) const
@@ -315,6 +331,25 @@ void USIOJsonObject::MergeJsonObject(USIOJsonObject* InJsonObject, bool Overwrit
 		
 		SetField(Key, InJsonObject->GetField(Key));
 	}
+}
+
+bool USIOJsonObject::TryGetObjectField(const FString& FieldName, USIOJsonObject*& OutObject) const
+{
+	if (!JsonObj.IsValid())
+	{
+		return false;
+	}
+
+	const TSharedPtr<FJsonObject>* JsonObjField;
+	bool bSuccess = JsonObj->TryGetObjectField(FieldName, JsonObjField);
+
+	if (bSuccess)
+	{
+		OutObject = NewObject<USIOJsonObject>();
+		OutObject->SetRootObject(*JsonObjField);
+	}
+
+	return bSuccess;
 }
 
 USIOJsonObject* USIOJsonObject::GetObjectField(const FString& FieldName) const

--- a/Source/SIOJson/Public/SIOJsonObject.h
+++ b/Source/SIOJson/Public/SIOJsonObject.h
@@ -89,6 +89,11 @@ class SIOJSON_API USIOJsonObject : public UObject
 	//////////////////////////////////////////////////////////////////////////
 	// FJsonObject API Helpers (easy to use with simple Json objects)
 
+	/** Attempt to get the field named FieldName as a number; returns false if it doesn't exist or the type is incorrect.
+	 * Attn.!! float used instead of double to make the function blueprintable! */
+	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
+	bool TryGetNumberField(const FString& FieldName, float& OutNumber) const;
+
 	/** Get the field named FieldName as a number. Ensures that the field is present and is of type Json number.
 	 * Attn.!! float used instead of double to make the function blueprintable! */
 	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
@@ -99,6 +104,10 @@ class SIOJSON_API USIOJsonObject : public UObject
 	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
 	void SetNumberField(const FString& FieldName, float Number);
 
+	/** Attempt to get the field named FieldName as a string; returns false if it doesn't exist or the type is incorrect. */
+	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
+	bool TryGetStringField(const FString& FieldName, FString& OutString) const;
+
 	/** Get the field named FieldName as a string. */
 	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
 	FString GetStringField(const FString& FieldName) const;
@@ -107,6 +116,10 @@ class SIOJSON_API USIOJsonObject : public UObject
 	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
 	void SetStringField(const FString& FieldName, const FString& StringValue);
 
+	/** Attempt to get the field named FieldName as a boolean; returns false if it doesn't exist or the type is incorrect. */
+	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
+	bool TryGetBoolField(const FString& FieldName, bool& OutBool) const;
+
 	/** Get the field named FieldName as a boolean. */
 	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
 	bool GetBoolField(const FString& FieldName) const;
@@ -114,6 +127,10 @@ class SIOJSON_API USIOJsonObject : public UObject
 	/** Set a boolean field named FieldName and value of InValue */
 	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
 	void SetBoolField(const FString& FieldName, bool InValue);
+
+	/** Attempt to get the field named FieldName as an object; returns false if it doesn't exist or the type is incorrect. */
+	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")
+	bool TryGetObjectField(const FString& FieldName, USIOJsonObject*& OutObject) const;
 
 	/** Get the field named FieldName as a Json object. */
 	UFUNCTION(BlueprintCallable, Category = "SIOJ|Json")


### PR DESCRIPTION
This PR adds some of the `TryGet...` methods to `USIOJsonObject`. I haven't tested all of these in engine, but I have tested `USIOJsonObject::TryGetStringField`