### PR TITLE
Replace raw uobject ptrs with TObjectPtr for UPROPERTY

### DIFF
--- a/Source/SIOJson/Public/SIOJLibrary.h
+++ b/Source/SIOJson/Public/SIOJLibrary.h
@@ -22,10 +22,10 @@ struct FSIOJCallResponse
 	GENERATED_USTRUCT_BODY()
 	
 	UPROPERTY()
-	USIOJRequestJSON* Request;
+	TObjectPtr<USIOJRequestJSON> Request;
 	
 	UPROPERTY()
-	UObject* WorldContextObject;
+	TObjectPtr<UObject> WorldContextObject;
 	
 	UPROPERTY()
 	FSIOJCallDelegate Callback;

--- a/Source/SIOJson/Public/SIOJRequestJSON.h
+++ b/Source/SIOJson/Public/SIOJRequestJSON.h
@@ -280,7 +280,7 @@ protected:
 
 	/** Internal request data stored as JSON */
 	UPROPERTY()
-	USIOJsonObject* RequestJsonObj;
+	TObjectPtr<USIOJsonObject> RequestJsonObj;
 
 	UPROPERTY()
 	TArray<uint8> RequestBytes;
@@ -290,7 +290,7 @@ protected:
 
 	/** Response data stored as JSON */
 	UPROPERTY()
-	USIOJsonObject* ResponseJsonObj;
+	TObjectPtr<USIOJsonObject> ResponseJsonObj;
 
 	/** Verb for making request (GET,POST,etc) */
 	ESIORequestVerb RequestVerb;


### PR DESCRIPTION
I have replaced Raw UObject pointers with TObjectPtr<> when used as UPROPERTY().