### PR TITLE
Fix iOS distribution crash by forcing ANSI allocator

### DIFF
--- a/Source/SocketIOClient/SocketIOClient.Build.cs
+++ b/Source/SocketIOClient/SocketIOClient.Build.cs
@@ -38,6 +38,7 @@ namespace UnrealBuildTool.Rules
             else if (Target.Platform == UnrealTargetPlatform.IOS)
             {
                 isLibrarySupported = true;
+                PublicDefinitions.Add("FORCE_ANSI_ALLOCATOR=1");
             }
             else if (Target.Platform == UnrealTargetPlatform.Mac)
             {


### PR DESCRIPTION
### Fix: iOS Distribution/TestFlight Crash (Memory Allocator Issue)

#### Problem
iOS builds crash in TestFlight / Distribution builds with:

Stack trace points to:
- websocketpp
- socket.io-client-cpp
- HTTP header parsing

Development builds work fine, but distribution builds consistently crash.

---

#### Solution
Force Unreal Engine to use ANSI allocator on iOS:

```csharp
if (Target.Platform == UnrealTargetPlatform.IOS)
{
    PublicDefinitions.Add("FORCE_ANSI_ALLOCATOR=1");
}