### PR TITLE
Fix two OnDisconnected lifecycle bugs (snapshot capture + premature sync fire)

### DIFF
--- a/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
+++ b/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
@@ -144,14 +144,15 @@ void USocketIOClientComponent::SetupCallbacks()
 		}
 	};
 
-	const FSIOCCloseEventSignature OnDisconnectedSafe = OnDisconnected;
-
-	NativeClient->OnDisconnectedCallback = [OnDisconnectedSafe, this](const ESIOConnectionCloseReason Reason)
+	// Broadcast on the live delegate, not a value-copy snapshot — SetupCallbacks runs in
+	// InitializeComponent (before BeginPlay), so handlers bound from BeginPlay would be
+	// missed by a snapshot taken here.
+	NativeClient->OnDisconnectedCallback = [this](const ESIOConnectionCloseReason Reason)
 	{
 		if (NativeClient.IsValid())
 		{
 			bIsConnected = false;
-			OnDisconnectedSafe.Broadcast(Reason);
+			OnDisconnected.Broadcast(Reason);
 		}
 	};
 
@@ -163,14 +164,12 @@ void USocketIOClientComponent::SetupCallbacks()
 		}
 	};
 
-	const FSIOCSocketEventSignature OnSocketNamespaceDisconnectedSafe = OnSocketNamespaceDisconnected;
-
-	NativeClient->OnNamespaceDisconnectedCallback = [this, OnSocketNamespaceDisconnectedSafe](const FString& Namespace)
+	// Broadcast on the live delegate (see OnDisconnectedCallback above for rationale).
+	NativeClient->OnNamespaceDisconnectedCallback = [this](const FString& Namespace)
 	{
-
 		if (NativeClient.IsValid())
 		{
-			OnSocketNamespaceDisconnectedSafe.Broadcast(Namespace);
+			OnSocketNamespaceDisconnected.Broadcast(Namespace);
 		}
 	};
 	NativeClient->OnReconnectionCallback = [this](const uint32 AttemptCount, const uint32 DelayInMs)

--- a/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
+++ b/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
@@ -130,84 +130,100 @@ void USocketIOClientComponent::SetupCallbacks()
 		URLParams = NativeClient->URLParams;
 	}
 
-	NativeClient->OnConnectedCallback = [this](const FString& InSocketId, const FString& InSessionId)
+	// Capture a weak pointer to this component rather than raw `this`.  These callbacks fire from
+	// the asio network thread and (when bCallbackOnGameThread is set) are marshalled to the game
+	// thread via a queued task.  The task can run after the component's owning world has torn down
+	// and the component itself has been destroyed, so the lambda must verify the component is still
+	// alive before touching any of its state.  A raw `this` capture with an `if (NativeClient.IsValid())`
+	// guard does not protect against this — reading this->NativeClient already dereferences the
+	// destroyed component.  TWeakObjectPtr::Get() returns null for pending-kill / destroyed objects.
+	TWeakObjectPtr<USocketIOClientComponent> WeakThis(this);
+
+	NativeClient->OnConnectedCallback = [WeakThis](const FString& InSocketId, const FString& InSessionId)
 	{
-		if (NativeClient.IsValid())
+		USocketIOClientComponent* Self = WeakThis.Get();
+		if (Self && Self->NativeClient.IsValid())
 		{
-			bIsConnected = true;
-			SocketId = InSocketId;
-			SessionId = InSessionId;
-			bool bIsReconnection = bIsHavingConnectionProblems;
-			bIsHavingConnectionProblems = false;
-			OnConnected.Broadcast(SocketId, SessionId, bIsReconnection);
-			
+			Self->bIsConnected = true;
+			Self->SocketId = InSocketId;
+			Self->SessionId = InSessionId;
+			bool bIsReconnection = Self->bIsHavingConnectionProblems;
+			Self->bIsHavingConnectionProblems = false;
+			Self->OnConnected.Broadcast(Self->SocketId, Self->SessionId, bIsReconnection);
+
 		}
 	};
 
 	// Broadcast on the live delegate, not a value-copy snapshot — SetupCallbacks runs in
 	// InitializeComponent (before BeginPlay), so handlers bound from BeginPlay would be
 	// missed by a snapshot taken here.
-	NativeClient->OnDisconnectedCallback = [this](const ESIOConnectionCloseReason Reason)
+	NativeClient->OnDisconnectedCallback = [WeakThis](const ESIOConnectionCloseReason Reason)
 	{
-		if (NativeClient.IsValid())
+		USocketIOClientComponent* Self = WeakThis.Get();
+		if (Self && Self->NativeClient.IsValid())
 		{
-			bIsConnected = false;
-			OnDisconnected.Broadcast(Reason);
+			Self->bIsConnected = false;
+			Self->OnDisconnected.Broadcast(Reason);
 		}
 	};
 
-	NativeClient->OnNamespaceConnectedCallback = [this](const FString& Namespace)
+	NativeClient->OnNamespaceConnectedCallback = [WeakThis](const FString& Namespace)
 	{
-		if (NativeClient.IsValid())
+		USocketIOClientComponent* Self = WeakThis.Get();
+		if (Self && Self->NativeClient.IsValid())
 		{
-			OnSocketNamespaceConnected.Broadcast(Namespace);
+			Self->OnSocketNamespaceConnected.Broadcast(Namespace);
 		}
 	};
 
 	// Broadcast on the live delegate (see OnDisconnectedCallback above for rationale).
-	NativeClient->OnNamespaceDisconnectedCallback = [this](const FString& Namespace)
+	NativeClient->OnNamespaceDisconnectedCallback = [WeakThis](const FString& Namespace)
 	{
-		if (NativeClient.IsValid())
+		USocketIOClientComponent* Self = WeakThis.Get();
+		if (Self && Self->NativeClient.IsValid())
 		{
-			OnSocketNamespaceDisconnected.Broadcast(Namespace);
+			Self->OnSocketNamespaceDisconnected.Broadcast(Namespace);
 		}
 	};
-	NativeClient->OnReconnectionCallback = [this](const uint32 AttemptCount, const uint32 DelayInMs)
+	NativeClient->OnReconnectionCallback = [WeakThis](const uint32 AttemptCount, const uint32 DelayInMs)
 	{
-		if (NativeClient.IsValid())
+		USocketIOClientComponent* Self = WeakThis.Get();
+		if (Self && Self->NativeClient.IsValid())
 		{
 			//First time we know about this problem?
-			if (!bIsHavingConnectionProblems)
+			if (!Self->bIsHavingConnectionProblems)
 			{
-				TimeWhenConnectionProblemsStarted = FDateTime::Now();
-				bIsHavingConnectionProblems = true;
+				Self->TimeWhenConnectionProblemsStarted = FDateTime::Now();
+				Self->bIsHavingConnectionProblems = true;
 			}
 
-			FTimespan Difference = FDateTime::Now() - TimeWhenConnectionProblemsStarted;
+			FTimespan Difference = FDateTime::Now() - Self->TimeWhenConnectionProblemsStarted;
 			float ElapsedInSec = Difference.GetTotalSeconds();
 
-			if (ReconnectionTimeout > 0 && ElapsedInSec > ReconnectionTimeout)
+			if (Self->ReconnectionTimeout > 0 && ElapsedInSec > Self->ReconnectionTimeout)
 			{
 				//Let's stop trying and disconnect if we're using timeouts
-				Disconnect();
+				Self->Disconnect();
 			}
-			OnConnectionProblems.Broadcast(AttemptCount, DelayInMs, ElapsedInSec);
+			Self->OnConnectionProblems.Broadcast(AttemptCount, DelayInMs, ElapsedInSec);
 		}
 	};
 
-	NativeClient->OnFailCallback = [this]()
+	NativeClient->OnFailCallback = [WeakThis]()
 	{
-		if(NativeClient.IsValid())
+		USocketIOClientComponent* Self = WeakThis.Get();
+		if (Self && Self->NativeClient.IsValid())
 		{
-			OnFail.Broadcast();
+			Self->OnFail.Broadcast();
 		};
 	};
 
-	NativeClient->OnErrorCallback = [this](const FString& Error)
+	NativeClient->OnErrorCallback = [WeakThis](const FString& Error)
 	{
-		if (NativeClient.IsValid())
+		USocketIOClientComponent* Self = WeakThis.Get();
+		if (Self && Self->NativeClient.IsValid())
 		{
-			OnError.Broadcast(Error);
+			Self->OnError.Broadcast(Error);
 		};
 	};
 }

--- a/Source/SocketIOClient/Private/SocketIONative.cpp
+++ b/Source/SocketIOClient/Private/SocketIONative.cpp
@@ -118,13 +118,11 @@ void FSocketIONative::LeaveNamespace(const FString& Namespace)
 }
 
 void FSocketIONative::Disconnect()
-{	
-	//Ensure disconnected callback is called first because we 
-	//clear all callbacks for stability.
-	if (OnDisconnectedCallback)
-	{
-		OnDisconnectedCallback(ESIOConnectionCloseReason::CLOSE_REASON_NORMAL);
-	}
+{
+	// OnDisconnectedCallback is fired asynchronously by the close_listener registered in
+	// SetupInternalCallbacks, after PrivateClient->close() completes. Firing it
+	// synchronously here would run while opened() is still true, so any handler that
+	// tries to reconnect would be rejected by Connect()'s !opened() guard.
 	bIsConnected = false;
 
 	if (bUnbindEventsOnDisconnect)


### PR DESCRIPTION
Two independent fixes to the disconnect lifecycle. They are unrelated bugs, presented as two commits in one PR; either commit can be accepted on its own.

### 1. `USocketIOClientComponent::SetupCallbacks` — broadcast on live delegate

`OnDisconnectedCallback` and `OnNamespaceDisconnectedCallback` were assigned lambdas that captured a value-copy snapshot of the `OnDisconnected` / `OnSocketNamespaceDisconnected` BlueprintAssignable
delegates. Because `SetupCallbacks()` runs in `InitializeComponent()` — before any other component's `BeginPlay()` — any subscriber that does `SocketIO->OnDisconnected.AddDynamic(...)` from `BeginPlay` (a very common pattern) ends up bound to the live delegate, but the lambda broadcasts on the snapshot, so the handler never fires.

The "Safe-snapshot" pattern looks intended to keep the lambda usable after `this` is destroyed, but the same lambda already dereferences `this->NativeClient` and `this->bIsConnected`, so the protection is incomplete in any case.

Fix: capture `this`, broadcast on the live `OnDisconnected` / `OnSocketNamespaceDisconnected` members, with a `NativeClient.IsValid()` null-check.

### 2. `FSocketIONative::Disconnect` — remove premature sync OnDisconnected fire

`Disconnect()` invoked `OnDisconnectedCallback(CLOSE_REASON_NORMAL)` synchronously, before calling `PrivateClient->close()`. At that moment `PrivateClient->opened()` is still `true`. Any handler that attempts to reconnect from inside the callback (a legitimate pattern) has its `ConnectNative` rejected by `Connect()`'s `if (PrivateClient->opened()) ... ignore` guard.

The async `close_listener` registered in `SetupInternalCallbacks` already invokes `OnDisconnectedCallback` *after* `close()` completes, at which point `opened()` is `false` and reconnect-from-callback works. Remove the early sync fire from `Disconnect()`.

`SyncDisconnect()` is left untouched — its sync fire is appropriate for the EndPlay path where the delegate is unbound immediately afterwards.

### Testing

Both fixes were exercised in a UE 5.7 project under reconnect-from-callback scenarios. With the previous code, BeginPlay-registered OnDisconnected handlers never fired, and in-callback reconnects were silently dropped. Both behaviors are resolved after these patches; existing disconnect paths (manual Disconnect, EndPlay SyncDisconnect, asio-driven close on network
failure) continue to deliver the callback exactly once.