### PR TITLE
Fix crash when a client is destroyed soon after disconnect

### DIFF
--- a/Source/SocketIOLib/Private/internal/sio_client_impl.h
+++ b/Source/SocketIOLib/Private/internal/sio_client_impl.h
@@ -127,6 +127,9 @@
             // used by sio::socket
             virtual void send(packet& p) {};
             virtual void remove_socket(std::string const& nsp) {};
+            // Unlike socket(), never creates the socket — returns null if the
+            // namespace is not (or no longer) registered.
+            virtual sio::socket::ptr find_socket(std::string const& nsp) { return sio::socket::ptr(); }
             virtual asio_sockio::io_service& get_io_service() = 0;
             virtual void on_socket_closed(std::string const& nsp) {};
             virtual void on_socket_opened(std::string const& nsp) {};
@@ -220,6 +223,8 @@
         void send(packet& p);
 
         void remove_socket(std::string const& nsp);
+
+        sio::socket::ptr find_socket(std::string const& nsp) override { return get_socket_locked(nsp); }
 
         asio_sockio::io_service& get_io_service();
 

--- a/Source/SocketIOLib/Private/sio_socket.cpp
+++ b/Source/SocketIOLib/Private/sio_socket.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 #include <cstdarg>
 #include <functional>
+#include <atomic>
 
 #if defined(DEBUG) && DEBUG
 #define LOG(x) std::cout << x
@@ -210,7 +211,12 @@ namespace sio
         error_listener m_error_listener;
         
         std::unique_ptr<asio_sockio::system_timer> m_connection_timer;
-        
+
+        // on_close() can be reached from two threads at once: the io thread
+        // (close-timer callback) and the client's teardown thread
+        // (~client_impl invokes it directly). Only one may run the teardown.
+        std::atomic<bool> m_close_invoked;
+
         std::queue<packet> m_packet_queue;
         
         std::mutex m_event_mutex;
@@ -261,7 +267,8 @@ namespace sio
         m_client(client),
         m_connected(false),
         m_nsp(nsp),
-        m_auth(auth)
+        m_auth(auth),
+        m_close_invoked(false)
     {
         NULL_GUARD(client);
         if(m_client->opened())
@@ -304,7 +311,11 @@ namespace sio
         m_connection_timer.reset(new asio_sockio::system_timer(m_client->get_io_service()));
         lib::error_code ec;
         m_connection_timer->expires_from_now(std::chrono::milliseconds(20000), ec);
-        m_connection_timer->async_wait(std::bind(&socket::impl::timeout_connection,this, std::placeholders::_1));
+        // No lifetime pin here: send_connect can run inside client_impl::socket(),
+        // which holds m_socket_mutex across construction — a find_socket lookup
+        // would relock the held mutex. Cancellation-at-teardown is instead
+        // covered by timeout_connection checking ec before touching any member.
+        m_connection_timer->async_wait(std::bind(&socket::impl::timeout_connection, this, std::placeholders::_1));
     }
     
     void socket::impl::close()
@@ -319,9 +330,26 @@ namespace sio
             {
                 m_connection_timer.reset(new asio_sockio::system_timer(m_client->get_io_service()));
             }
+            // Pin the owning socket so the deferred on_close can never run on
+            // a freed impl. If the socket is no longer registered, teardown is
+            // already being handled elsewhere — skip the deferred close.
+            sio::socket::ptr self = m_client->find_socket(m_nsp);
+            if(!self)
+            {
+                return;
+            }
             lib::error_code ec;
             m_connection_timer->expires_from_now(std::chrono::milliseconds(3000), ec);
-            m_connection_timer->async_wait(std::bind(&socket::impl::on_close, this));
+            m_connection_timer->async_wait([this, self](const asio_sockio::error_code& timer_ec)
+            {
+                // Cancelled (connection re-established, or teardown already ran
+                // on_close directly) — the deferred close must not fire.
+                if(timer_ec)
+                {
+                    return;
+                }
+                on_close();
+            });
         }
     }
     
@@ -354,6 +382,13 @@ namespace sio
     
     void socket::impl::on_close()
     {
+        // The close-timer callback (io thread) and ~client_impl's direct call
+        // (teardown thread) can both reach this on a live socket; teardown is
+        // terminal (remove_socket below), so it must run exactly once.
+        if(m_close_invoked.exchange(true))
+        {
+            return;
+        }
         NULL_GUARD(m_client);
         sio::client_impl_base *client = m_client;
         m_client = NULL;
@@ -515,11 +550,14 @@ namespace sio
     
     void socket::impl::timeout_connection(const lib::error_code &ec)
     {
-        NULL_GUARD(m_client);
+        // Check the timer result before touching any member: on cancellation
+        // during teardown `this` may already be freed (constructor-armed timer
+        // has no lifetime pin — see send_connect).
         if(ec)
         {
             return;
         }
+        NULL_GUARD(m_client);
         m_connection_timer.reset();
         LOG("Connection timeout,close socket."<<std::endl);
         //Should close socket if no connected message arrive.Otherwise we'll never ask for open again.


### PR DESCRIPTION
### What's going on

I kept getting random access-violation crashes whenever I tore a client down shortly after disconnecting it. In my case it was an Unreal Engine level switch, but it's not Unreal-specific — any `close()` followed by destroying the client within about 3 seconds can trigger it.

### The cause

It comes down to the timer that `socket::impl::close()` arms:

#### cpp
m_connection_timer->async_wait(std::bind(&socket::impl::on_close, this));

#### Two problems with that one line:
it binds a raw this, and the handler never looks at asio's error_code, so it runs even when the timer was cancelled.
So here's the race: you call close(), which arms the 3-second timer. The client gets destroyed inside that window. ~client_impl() calls on_close() directly, and remove_socket() frees the socket::impl. asio then delivers the cancelled timer's callback on the io thread, which calls on_close() a second time — on memory that's already been freed. That's the crash.

### The fix
close() — the timer handler now bails out early if the error_code says it was cancelled, and it holds a shared_ptr to the socket so the callback can't outlive it. If the socket is already gone, we don't arm the timer at all. on_close() — added an atomic guard so the timer callback and the destructor's direct call can't both run the teardown. timeout_connection() — moved the error_code check ahead of NULL_GUARD(m_client); the old order touched a member before checking whether the wait had been cancelled. I deliberately left this timer without the shared_ptr pin: send_connect() can run from inside client_impl::socket() while m_socket_mutex is held, so looking the socket up there would deadlock. Added a small find_socket() helper that looks a socket up without creating one (socket() creates it as a side effect, which we don't want here).

### Testing
Built and ran through repeated connect / disconnect / reconnect cycles, including destroying the client immediately after a disconnect (the exact window that used to crash). No more crashes, and a normal disconnect still tears down cleanly.