### PR TITLE
Fix process abort when a server PING arrives during connection teardown

### DIFF
--- a/Source/SocketIOLib/Private/internal/sio_client_impl.cpp
+++ b/Source/SocketIOLib/Private/internal/sio_client_impl.cpp
@@ -609,7 +609,16 @@ namespace sio
         packet p(packet::frame_pong);
         m_packet_mgr.encode(p, [&](bool /*isBin*/, shared_ptr<const string> payload)
             {
-                this->m_client.send(this->m_con, *payload, frame::opcode::text);
+                // Mirror send_impl()/ping(): only send when the connection is OPEN and use
+                // the non-throwing error_code overload. The throwing overload aborts the whole
+                // process if a server PING lands on a connection that is mid-teardown
+                // (websocketpp throws invalid_state/bad_connection, which is unhandled on the
+                // asio network thread). A dropped PONG on a closing connection is harmless.
+                if (m_con_state == con_opened)
+                {
+                    lib::error_code ec;
+                    this->m_client.send(this->m_con, *payload, frame::opcode::text, ec);
+                }
             });
 
         if (m_ping_timeout_timer)


### PR DESCRIPTION
on_ping() replied to server PINGs with the throwing websocketpp send overload, unlike send_impl()/ping() which use the non-throwing error_code overload and guard on con_opened. If a PING lands while the connection is tearing down, websocketpp throws (invalid_state/bad_connection) on the asio network thread, which run_loop() did not catch, so it propagated to std::terminate -> abort and killed the whole process. Seen under connect/disconnect churn (reconnects, level transitions) in a packaged UE5 build.

on_ping() now mirrors send_impl()/ping(): only send when con_opened and use the error_code overload. run_loop() additionally wraps m_client.run() in a try/catch so no stray handler exception can ever take the process down.