### PR TITLE
Sync component settings to native client in ConnectWithParams

### DIFF
--- a/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
+++ b/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
@@ -441,6 +441,11 @@ void USocketIOClientComponent::Connect(const FString& InAddressAndPort, const FS
 		URLParams.AuthToken = InAuthToken;
 	}
 
+	ConnectWithParams(URLParams);
+}
+
+void USocketIOClientComponent::ConnectWithParams(const FSIOConnectParams& InURLParams)
+{
 	//Sync all params to native client before connecting
 	NativeClient->MaxReconnectionAttempts = MaxReconnectionAttempts;
 	NativeClient->ReconnectionDelay = ReconnectionDelayInMs;
@@ -448,11 +453,6 @@ void USocketIOClientComponent::Connect(const FString& InAddressAndPort, const FS
 	NativeClient->bUnbindEventsOnDisconnect = bUnbindEventsOnDisconnect;
 	NativeClient->bForceTLSUse = bForceTLS;
 
-	ConnectWithParams(URLParams);
-}
-
-void USocketIOClientComponent::ConnectWithParams(const FSIOConnectParams& InURLParams)
-{
 	NativeClient->Connect(InURLParams);
 
 	OnErrorEvent([this](const FString& Error)


### PR DESCRIPTION
Connect() synced MaxReconnectionAttempts/ReconnectionDelay/VerboseLog/ bUnbindEventsOnDisconnect/bForceTLS to the native client before connecting, but the ConnectNative/ConnectWithParams entry points did not, so settings made by C++ callers were silently ignored (e.g. reconnect attempts stayed at the FSocketIONative default of -1/infinite regardless of the component property).

Moving the sync into ConnectWithParams covers all connect entry points; Blueprint Connect() path behavior is unchanged since it funnels through ConnectWithParams.